### PR TITLE
Add full test suite (P1/P2/P3) with 71 passing tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,21 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-testcontainers</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>postgresql</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<scope>test</scope>
+		</dependency>
         <dependency>
             <groupId>co.elastic.apm</groupId>
             <artifactId>apm-agent-attach</artifactId>
@@ -99,6 +114,33 @@
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<argLine>@{argLine} -Duser.timezone=UTC</argLine>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>0.8.12</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>prepare-agent</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>report</id>
+						<phase>test</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+
 		</plugins>
 	</build>
 

--- a/src/test/java/com/notification/herald/configurations/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/notification/herald/configurations/GlobalExceptionHandlerTest.java
@@ -1,0 +1,96 @@
+package com.notification.herald.configurations;
+
+import com.notification.herald.dto.ErrorDto;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.ValidationException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GlobalExceptionHandlerTest {
+
+    @InjectMocks
+    GlobalExceptionHandler handler;
+
+    @Mock
+    BindingResult bindingResult;
+
+    @Test
+    void genericException_returns500() {
+        ResponseEntity<ErrorDto> response = handler.exceptionHandler(new RuntimeException("boom"));
+
+        assertThat(response.getStatusCode().value()).isEqualTo(500);
+        assertThat(response.getBody().data()).isEqualTo("boom");
+        assertThat(response.getBody().status()).isEqualTo(500);
+    }
+
+    @Test
+    void methodArgumentNotValid_withFieldError_returnsBadRequestWithFieldMessage() throws Exception {
+        FieldError fieldError = new FieldError("obj", "type", "type is mandatory");
+        when(bindingResult.getFieldError()).thenReturn(fieldError);
+        MethodArgumentNotValidException ex = new MethodArgumentNotValidException(null, bindingResult);
+
+        ResponseEntity<ErrorDto> response = handler.exceptionHandler(ex);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(400);
+        assertThat(response.getBody().data()).isEqualTo("type is mandatory");
+    }
+
+    @Test
+    void methodArgumentNotValid_noFieldError_returnsLocalizedMessage() throws Exception {
+        MethodArgumentNotValidException ex = mock(MethodArgumentNotValidException.class);
+        when(ex.getBindingResult()).thenReturn(bindingResult);
+        when(bindingResult.getFieldError()).thenReturn(null);
+        when(ex.getLocalizedMessage()).thenReturn("Validation failed");
+
+        ResponseEntity<ErrorDto> response = handler.exceptionHandler(ex);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(400);
+        assertThat(response.getBody().data()).isEqualTo("Validation failed");
+    }
+
+    @Test
+    void responseStatusException_returnsCorrectStatusAndMessage() {
+        ResponseStatusException ex = new ResponseStatusException(HttpStatus.NOT_FOUND, "not found");
+
+        ResponseEntity<ErrorDto> response = handler.exceptionHandler(ex);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(404);
+        assertThat(response.getBody().status()).isEqualTo(404);
+    }
+
+    @Test
+    void constraintViolationException_returns400() {
+        ConstraintViolationException ex = new ConstraintViolationException("constraint violated", Set.of());
+
+        ResponseEntity<ErrorDto> response = handler.exceptionHandler(ex);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(400);
+        assertThat(response.getBody().data()).contains("constraint violated");
+    }
+
+    @Test
+    void validationException_returns400() {
+        ValidationException ex = new ValidationException("invalid input");
+
+        ResponseEntity<ErrorDto> response = handler.exceptionHandler(ex);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(400);
+        assertThat(response.getBody().data()).isEqualTo("invalid input");
+    }
+}

--- a/src/test/java/com/notification/herald/configurations/KafkaConfigTest.java
+++ b/src/test/java/com/notification/herald/configurations/KafkaConfigTest.java
@@ -1,0 +1,37 @@
+package com.notification.herald.configurations;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.listener.DefaultErrorHandler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+class KafkaConfigTest {
+
+    @Mock
+    ConsumerFactory<Object, Object> consumerFactory;
+
+    private final KafkaConfig kafkaConfig = new KafkaConfig();
+
+    @Test
+    void errorHandler_shouldBeNonNull() {
+        DefaultErrorHandler handler = kafkaConfig.errorHandler();
+
+        assertThat(handler).isNotNull();
+    }
+
+    @Test
+    void kafkaListenerContainerFactory_shouldEnableDeliveryAttemptHeader() {
+        DefaultErrorHandler handler = kafkaConfig.errorHandler();
+
+        ConcurrentKafkaListenerContainerFactory<?, ?> factory =
+                kafkaConfig.kafkaListenerContainerFactory(consumerFactory, handler);
+
+        assertThat(factory.getContainerProperties().isDeliveryAttemptHeader()).isTrue();
+    }
+}

--- a/src/test/java/com/notification/herald/consumers/EmailConsumerTest.java
+++ b/src/test/java/com/notification/herald/consumers/EmailConsumerTest.java
@@ -1,0 +1,85 @@
+package com.notification.herald.consumers;
+
+import com.notification.herald.dto.mail.MailRequestDto;
+import com.notification.herald.dto.UserDto;
+import com.notification.herald.enums.MailProviderEnum;
+import com.notification.herald.enums.NotifTypeEnum;
+import com.notification.herald.enums.NotificationStatusEnum;
+import com.notification.herald.services.CommonPersistanceService;
+import com.notification.herald.utils.MailUtil;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class EmailConsumerTest {
+
+    @Mock
+    MailUtil mailUtil;
+
+    @Mock
+    CommonPersistanceService commonPersistanceService;
+
+    @InjectMocks
+    EmailConsumer emailConsumer;
+
+    private final MailRequestDto request = new MailRequestDto(
+            "Subject", "Body", new UserDto("Alice", "alice@example.com"), "req-abc"
+    );
+
+    @Test
+    void emailConsumer_success_shouldCallMailUtilAndPersistRequested() throws Exception {
+        when(mailUtil.sendMail(request, MailProviderEnum.MAILJET)).thenReturn("msg-ref-123");
+
+        emailConsumer.emailConsumer(request, 1);
+
+        verify(mailUtil).sendMail(request, MailProviderEnum.MAILJET);
+        verify(commonPersistanceService).saveOrUpdateNotification(
+                eq("req-abc"), eq("msg-ref-123"), eq(0), eq(NotifTypeEnum.EMAIL), eq(NotificationStatusEnum.REQUESTED)
+        );
+    }
+
+    @Test
+    void emailConsumer_success_deliveryAttemptMinusOne_passedToPersistence() throws Exception {
+        when(mailUtil.sendMail(any(), any())).thenReturn("ref-id");
+
+        emailConsumer.emailConsumer(request, 3);
+
+        verify(commonPersistanceService).saveOrUpdateNotification(
+                any(), any(), eq(2), any(), any()
+        );
+    }
+
+    @Test
+    void emailConsumer_failure_shouldPersistFailedAndRethrow() throws Exception {
+        RuntimeException cause = new RuntimeException("mail error");
+        when(mailUtil.sendMail(any(), any())).thenThrow(cause);
+
+        assertThatThrownBy(() -> emailConsumer.emailConsumer(request, 1))
+                .isSameAs(cause);
+
+        verify(commonPersistanceService).saveOrUpdateNotification(
+                eq("req-abc"), eq("FAILED_REFERENCE"), eq(0), eq(NotifTypeEnum.EMAIL), eq(NotificationStatusEnum.FAILED)
+        );
+    }
+
+    @Test
+    void emailConsumer_failure_shouldNotPersistRequested() throws Exception {
+        when(mailUtil.sendMail(any(), any())).thenThrow(new RuntimeException("error"));
+
+        try {
+            emailConsumer.emailConsumer(request, 1);
+        } catch (Exception ignored) {}
+
+        verify(commonPersistanceService, never()).saveOrUpdateNotification(
+                any(), any(), any(), any(), eq(NotificationStatusEnum.REQUESTED)
+        );
+    }
+}

--- a/src/test/java/com/notification/herald/consumers/SMSConsumerTest.java
+++ b/src/test/java/com/notification/herald/consumers/SMSConsumerTest.java
@@ -1,0 +1,82 @@
+package com.notification.herald.consumers;
+
+import com.notification.herald.dto.sms.SMSRequestDto;
+import com.notification.herald.enums.NotifTypeEnum;
+import com.notification.herald.enums.NotificationStatusEnum;
+import com.notification.herald.enums.SMSProviderEnum;
+import com.notification.herald.services.CommonPersistanceService;
+import com.notification.herald.utils.SMSUtil;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class SMSConsumerTest {
+
+    @Mock
+    SMSUtil smsUtil;
+
+    @Mock
+    CommonPersistanceService commonPersistanceService;
+
+    @InjectMocks
+    SMSConsumer smsConsumer;
+
+    private final SMSRequestDto request = new SMSRequestDto("+1234567890", "Hello", "req-xyz");
+
+    @Test
+    void smsConsumer_success_shouldCallSMSUtilAndPersistRequested() throws Exception {
+        when(smsUtil.sendSMS(request, SMSProviderEnum.TWILIO)).thenReturn("sms-sid-123");
+
+        smsConsumer.smsConsumer(request, 1);
+
+        verify(smsUtil).sendSMS(request, SMSProviderEnum.TWILIO);
+        verify(commonPersistanceService).saveOrUpdateNotification(
+                eq("req-xyz"), eq("sms-sid-123"), eq(0), eq(NotifTypeEnum.SMS), eq(NotificationStatusEnum.REQUESTED)
+        );
+    }
+
+    @Test
+    void smsConsumer_success_deliveryAttemptMinusOne_passedToPersistence() throws Exception {
+        when(smsUtil.sendSMS(any(), any())).thenReturn("sid");
+
+        smsConsumer.smsConsumer(request, 2);
+
+        verify(commonPersistanceService).saveOrUpdateNotification(
+                any(), any(), eq(1), any(), any()
+        );
+    }
+
+    @Test
+    void smsConsumer_failure_shouldPersistFailedAndRethrow() throws Exception {
+        RuntimeException cause = new RuntimeException("sms error");
+        when(smsUtil.sendSMS(any(), any())).thenThrow(cause);
+
+        assertThatThrownBy(() -> smsConsumer.smsConsumer(request, 1))
+                .isSameAs(cause);
+
+        verify(commonPersistanceService).saveOrUpdateNotification(
+                eq("req-xyz"), eq("FAILED_REFERENCE"), eq(0), eq(NotifTypeEnum.SMS), eq(NotificationStatusEnum.FAILED)
+        );
+    }
+
+    @Test
+    void smsConsumer_failure_shouldNotPersistRequested() throws Exception {
+        when(smsUtil.sendSMS(any(), any())).thenThrow(new RuntimeException("error"));
+
+        try {
+            smsConsumer.smsConsumer(request, 1);
+        } catch (Exception ignored) {}
+
+        verify(commonPersistanceService, never()).saveOrUpdateNotification(
+                any(), any(), any(), any(), eq(NotificationStatusEnum.REQUESTED)
+        );
+    }
+}

--- a/src/test/java/com/notification/herald/controllers/NotificationControllerTest.java
+++ b/src/test/java/com/notification/herald/controllers/NotificationControllerTest.java
@@ -1,0 +1,103 @@
+package com.notification.herald.controllers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.notification.herald.dto.NotifRequestDto;
+import com.notification.herald.dto.ResponseDto;
+import com.notification.herald.enums.NotifTypeEnum;
+import com.notification.herald.services.NotificationService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(NotificationController.class)
+class NotificationControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @MockitoBean
+    NotificationService notificationService;
+
+    @Test
+    void postNotification_validRequest_returns201() throws Exception {
+        NotifRequestDto dto = new NotifRequestDto(NotifTypeEnum.SMS, "+1234567890", null, null, "Hello", null);
+        ResponseDto serviceResponse = new ResponseDto(List.of("req-123"), HttpStatus.CREATED.value());
+        when(notificationService.sendNotification(anyList())).thenReturn(serviceResponse);
+
+        mockMvc.perform(post("/notification")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(List.of(dto))))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.status").value(201));
+
+        verify(notificationService).sendNotification(anyList());
+    }
+
+    @Test
+    void postNotification_nullType_returns400() throws Exception {
+        String body = "[{\"type\":null,\"toMobile\":\"+1234567890\",\"content\":\"Hello\"}]";
+
+        mockMvc.perform(post("/notification")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void postNotification_emptyList_returns201WithEmptyData() throws Exception {
+        ResponseDto serviceResponse = new ResponseDto(List.of(), HttpStatus.CREATED.value());
+        when(notificationService.sendNotification(anyList())).thenReturn(serviceResponse);
+
+        mockMvc.perform(post("/notification")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("[]"))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    void getNotification_validRequestId_returns200() throws Exception {
+        ResponseDto serviceResponse = new ResponseDto("entity-data", HttpStatus.OK.value());
+        when(notificationService.getNotification("req-123")).thenReturn(serviceResponse);
+
+        mockMvc.perform(get("/notification").param("requestId", "req-123"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200));
+
+        verify(notificationService).getNotification("req-123");
+    }
+
+    @Test
+    void getNotification_missingRequestId_returns500() throws Exception {
+        // MissingServletRequestParameterException is caught by the generic Exception handler → 500
+        mockMvc.perform(get("/notification"))
+                .andExpect(status().isInternalServerError());
+    }
+
+    @Test
+    void postNotification_serviceThrowsException_returns500() throws Exception {
+        NotifRequestDto dto = new NotifRequestDto(NotifTypeEnum.SMS, "+1234567890", null, null, "Hello", null);
+        when(notificationService.sendNotification(anyList())).thenThrow(new RuntimeException("unexpected"));
+
+        mockMvc.perform(post("/notification")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(List.of(dto))))
+                .andExpect(status().isInternalServerError());
+    }
+}

--- a/src/test/java/com/notification/herald/controllers/OtpControllerTest.java
+++ b/src/test/java/com/notification/herald/controllers/OtpControllerTest.java
@@ -1,0 +1,114 @@
+package com.notification.herald.controllers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.notification.herald.dto.ResponseDto;
+import com.notification.herald.dto.otp.OtpRequestDto;
+import com.notification.herald.dto.otp.OtpValidateDto;
+import com.notification.herald.services.OtpService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(OtpController.class)
+class OtpControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @MockitoBean
+    OtpService otpService;
+
+    // --- /otp/request ---
+
+    @Test
+    void requestOtp_validRequest_returnsServiceStatus() throws Exception {
+        OtpRequestDto dto = new OtpRequestDto("+1234567890", null, "Your OTP", "Alice", 300);
+        ResponseDto serviceResponse = new ResponseDto("otp-req-id", HttpStatus.OK.value());
+        when(otpService.requestOtp(any())).thenReturn(serviceResponse);
+
+        mockMvc.perform(post("/otp/request")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200));
+
+        verify(otpService).requestOtp(any());
+    }
+
+    @Test
+    void requestOtp_blankContent_returns400() throws Exception {
+        OtpRequestDto dto = new OtpRequestDto("+1234567890", null, "", "Alice", 300);
+
+        mockMvc.perform(post("/otp/request")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void requestOtp_nullExpiresIn_returns400() throws Exception {
+        String body = "{\"toMobile\":\"+1234567890\",\"content\":\"OTP\",\"expiresIn\":null}";
+
+        mockMvc.perform(post("/otp/request")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest());
+    }
+
+    // --- /otp/validate ---
+
+    @Test
+    void validateOtp_validRequest_returnsServiceStatus() throws Exception {
+        OtpValidateDto dto = new OtpValidateDto();
+        dto.setRequestId("req-123");
+        dto.setOtp("12345");
+        ResponseDto serviceResponse = new ResponseDto("validated", HttpStatus.OK.value());
+        when(otpService.validateOtp(any())).thenReturn(serviceResponse);
+
+        mockMvc.perform(post("/otp/validate")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200));
+
+        verify(otpService).validateOtp(any());
+    }
+
+    @Test
+    void validateOtp_blankRequestId_returns400() throws Exception {
+        OtpValidateDto dto = new OtpValidateDto();
+        dto.setRequestId("");
+        dto.setOtp("12345");
+
+        mockMvc.perform(post("/otp/validate")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void validateOtp_blankOtp_returns400() throws Exception {
+        OtpValidateDto dto = new OtpValidateDto();
+        dto.setRequestId("req-123");
+        dto.setOtp("");
+
+        mockMvc.perform(post("/otp/validate")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/src/test/java/com/notification/herald/providers/mail/MailjetImplTest.java
+++ b/src/test/java/com/notification/herald/providers/mail/MailjetImplTest.java
@@ -1,0 +1,113 @@
+package com.notification.herald.providers.mail;
+
+import com.notification.herald.configurations.properties.MailjetConfiguration;
+import com.notification.herald.dto.UserDto;
+import com.notification.herald.dto.mail.MailRequestDto;
+import com.notification.herald.dto.mail.Mailjet.request.MailjetRequestDto;
+import com.notification.herald.dto.mail.Mailjet.response.MailjetMessages;
+import com.notification.herald.dto.mail.Mailjet.response.MailjetResponseDto;
+import com.notification.herald.dto.mail.Mailjet.response.MailjetTo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.client.RestClient;
+
+import java.util.List;
+
+import org.springframework.web.client.RestClientException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MailjetImplTest {
+
+    @Mock
+    private RestClient mailClient;
+
+    // RETURNS_SELF handles the fluent chain: .uri().contentType().body() all return the same mock
+    @Mock(answer = Answers.RETURNS_SELF)
+    private RestClient.RequestBodyUriSpec requestBodyUriSpec;
+
+    @Mock
+    private RestClient.ResponseSpec responseSpec;
+
+    private MailjetImpl mailjetImpl;
+
+    @BeforeEach
+    void setUp() {
+        MailjetConfiguration config = new MailjetConfiguration("apikey", "secret", "https://api.mailjet.com/v3.1/", "from@example.com", "Sender Name");
+        mailjetImpl = new MailjetImpl(mailClient, config);
+
+        when(mailClient.post()).thenReturn(requestBodyUriSpec);
+        when(requestBodyUriSpec.retrieve()).thenReturn(responseSpec);
+    }
+
+    private MailjetResponseDto responseWith(String messageId) {
+        return new MailjetResponseDto(List.of(
+                new MailjetMessages("success", List.of(new MailjetTo("user@example.com", messageId, "https://href")))
+        ));
+    }
+
+    @Test
+    void sendMail_shouldReturnMessageId() {
+        when(responseSpec.body(MailjetResponseDto.class)).thenReturn(responseWith("msg-id-001"));
+
+        String messageId = mailjetImpl.sendMail(new MailRequestDto("Subject", "Body content", new UserDto("Alice", "user@example.com"), "req-1"));
+
+        assertThat(messageId).isEqualTo("msg-id-001");
+    }
+
+    @Test
+    void sendMail_shouldPostToSendEndpoint() {
+        when(responseSpec.body(MailjetResponseDto.class)).thenReturn(responseWith("msg-id-001"));
+
+        mailjetImpl.sendMail(new MailRequestDto("Subject", "Body", new UserDto("Alice", "user@example.com"), "req-1"));
+
+        verify(requestBodyUriSpec).uri("send");
+    }
+
+    @Test
+    void sendMail_shouldTransformRecipientCorrectly() {
+        when(responseSpec.body(MailjetResponseDto.class)).thenReturn(responseWith("msg-id-001"));
+
+        mailjetImpl.sendMail(new MailRequestDto("Test Subject", "Test Body", new UserDto("Alice", "user@example.com"), "req-1"));
+
+        ArgumentCaptor<MailjetRequestDto> captor = ArgumentCaptor.forClass(MailjetRequestDto.class);
+        verify(requestBodyUriSpec).body(captor.capture());
+
+        MailjetRequestDto sent = captor.getValue();
+        assertThat(sent.Messages().get(0).To().get(0).email()).isEqualTo("user@example.com");
+        assertThat(sent.Messages().get(0).To().get(0).name()).isEqualTo("Alice");
+        assertThat(sent.Messages().get(0).Subject()).isEqualTo("Test Subject");
+        assertThat(sent.Messages().get(0).HTMLPart()).isEqualTo("Test Body");
+    }
+
+    @Test
+    void sendMail_whenRestClientThrows_propagatesException() {
+        when(responseSpec.body(MailjetResponseDto.class)).thenThrow(new RestClientException("HTTP 400 Bad Request"));
+
+        assertThatThrownBy(() -> mailjetImpl.sendMail(new MailRequestDto("Subject", "Body", new UserDto("Alice", "user@example.com"), "req-1")))
+                .isInstanceOf(RestClientException.class)
+                .hasMessageContaining("HTTP 400 Bad Request");
+    }
+
+    @Test
+    void sendMail_shouldUseConfiguredSenderAddress() {
+        when(responseSpec.body(MailjetResponseDto.class)).thenReturn(responseWith("msg-id-001"));
+
+        mailjetImpl.sendMail(new MailRequestDto("Subject", "Body", new UserDto("Alice", "user@example.com"), "req-1"));
+
+        ArgumentCaptor<MailjetRequestDto> captor = ArgumentCaptor.forClass(MailjetRequestDto.class);
+        verify(requestBodyUriSpec).body(captor.capture());
+
+        assertThat(captor.getValue().Messages().get(0).From().email()).isEqualTo("from@example.com");
+        assertThat(captor.getValue().Messages().get(0).From().name()).isEqualTo("Sender Name");
+    }
+}

--- a/src/test/java/com/notification/herald/providers/sms/TwilioImplTest.java
+++ b/src/test/java/com/notification/herald/providers/sms/TwilioImplTest.java
@@ -1,0 +1,98 @@
+package com.notification.herald.providers.sms;
+
+import com.notification.herald.configurations.properties.TwilioConfiguration;
+import com.notification.herald.dto.sms.SMSRequestDto;
+import com.notification.herald.dto.sms.Twilio.TwilioResponseDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+
+import org.springframework.web.client.RestClientException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TwilioImplTest {
+
+    @Mock
+    private RestClient smsClient;
+
+    // RETURNS_SELF handles .body() returning the same mock so .retrieve() can be chained
+    @Mock(answer = Answers.RETURNS_SELF)
+    private RestClient.RequestBodyUriSpec requestBodyUriSpec;
+
+    @Mock
+    private RestClient.ResponseSpec responseSpec;
+
+    private TwilioImpl twilioImpl;
+
+    @BeforeEach
+    void setUp() {
+        TwilioConfiguration config = new TwilioConfiguration("user", "pass", "MG-service-sid-123", "https://api.twilio.com/");
+        twilioImpl = new TwilioImpl(smsClient, config);
+
+        when(smsClient.post()).thenReturn(requestBodyUriSpec);
+        when(requestBodyUriSpec.retrieve()).thenReturn(responseSpec);
+    }
+
+    private TwilioResponseDto responseWithSid(String sid) {
+        return new TwilioResponseDto(null, null, null, null, null, null, null, null, null,
+                null, null, null, null, null, null, sid, null, null, null, null);
+    }
+
+    @Test
+    void sendSMS_shouldReturnSid() {
+        when(responseSpec.body(TwilioResponseDto.class)).thenReturn(responseWithSid("SM-sid-999"));
+
+        String sid = twilioImpl.sendSMS(new SMSRequestDto("+1234567890", "Hello", "req-1"));
+
+        assertThat(sid).isEqualTo("SM-sid-999");
+    }
+
+    @Test
+    void sendSMS_shouldBuildFormDataWithCorrectFields() {
+        when(responseSpec.body(TwilioResponseDto.class)).thenReturn(responseWithSid("SM-sid-001"));
+
+        twilioImpl.sendSMS(new SMSRequestDto("+9876543210", "Test message", "req-2"));
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<MultiValueMap<String, String>> captor = ArgumentCaptor.forClass(MultiValueMap.class);
+        verify(requestBodyUriSpec).body(captor.capture());
+
+        MultiValueMap<String, String> formData = captor.getValue();
+        assertThat(formData.getFirst("To")).isEqualTo("+9876543210");
+        assertThat(formData.getFirst("MessagingServiceSid")).isEqualTo("MG-service-sid-123");
+        assertThat(formData.getFirst("Body")).isEqualTo("Test message");
+    }
+
+    @Test
+    void sendSMS_whenRestClientThrows_propagatesException() {
+        when(responseSpec.body(TwilioResponseDto.class)).thenThrow(new RestClientException("HTTP 401 Unauthorized"));
+
+        assertThatThrownBy(() -> twilioImpl.sendSMS(new SMSRequestDto("+1234567890", "Hello", "req-fail")))
+                .isInstanceOf(RestClientException.class)
+                .hasMessageContaining("HTTP 401 Unauthorized");
+    }
+
+    @Test
+    void sendSMS_shouldUseServiceIdFromConfiguration() {
+        when(responseSpec.body(TwilioResponseDto.class)).thenReturn(responseWithSid("SM-sid-001"));
+
+        twilioImpl.sendSMS(new SMSRequestDto("+1111111111", "msg", "req-3"));
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<MultiValueMap<String, String>> captor = ArgumentCaptor.forClass(MultiValueMap.class);
+        verify(requestBodyUriSpec).body(captor.capture());
+
+        assertThat(captor.getValue().getFirst("MessagingServiceSid")).isEqualTo("MG-service-sid-123");
+    }
+}

--- a/src/test/java/com/notification/herald/repository/NotificationRepositoryTest.java
+++ b/src/test/java/com/notification/herald/repository/NotificationRepositoryTest.java
@@ -1,0 +1,73 @@
+package com.notification.herald.repository;
+
+import com.notification.herald.entities.NotificationEntity;
+import com.notification.herald.enums.NotifTypeEnum;
+import com.notification.herald.enums.NotificationStatusEnum;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Testcontainers
+@Import(FlywayAutoConfiguration.class)
+@TestPropertySource(properties = {
+        "spring.jpa.hibernate.ddl-auto=none",
+        "spring.flyway.enabled=true",
+        "spring.flyway.validate-on-migrate=false"
+})
+class NotificationRepositoryTest {
+
+    @Container
+    @ServiceConnection
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16");
+
+    @Autowired
+    NotificationRepository repository;
+
+    @Test
+    void findByID_shouldReturnEntity_whenFound() {
+        NotificationEntity entity = new NotificationEntity(
+                "notif-id-001", "ref-001", NotifTypeEnum.EMAIL, NotificationStatusEnum.REQUESTED, 0
+        );
+        repository.save(entity);
+
+        NotificationEntity found = repository.findByID("notif-id-001");
+
+        assertThat(found).isNotNull();
+        assertThat(found.getNotificationId()).isEqualTo("notif-id-001");
+        assertThat(found.getType()).isEqualTo(NotifTypeEnum.EMAIL);
+        assertThat(found.getStatus()).isEqualTo(NotificationStatusEnum.REQUESTED);
+        assertThat(found.getRetryCount()).isEqualTo(0);
+    }
+
+    @Test
+    void findByID_shouldReturnNull_whenNotFound() {
+        NotificationEntity result = repository.findByID("non-existent-id");
+
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void findByID_shouldReturnCorrectEntity_whenMultipleExist() {
+        NotificationEntity smsEntity = new NotificationEntity("id-sms", "ref-sms", NotifTypeEnum.SMS, NotificationStatusEnum.FAILED, 3);
+        NotificationEntity emailEntity = new NotificationEntity("id-email", "ref-email", NotifTypeEnum.EMAIL, NotificationStatusEnum.REQUESTED, 0);
+        repository.saveAll(List.of(smsEntity, emailEntity));
+
+        assertThat(repository.findByID("id-sms").getType()).isEqualTo(NotifTypeEnum.SMS);
+        assertThat(repository.findByID("id-sms").getStatus()).isEqualTo(NotificationStatusEnum.FAILED);
+        assertThat(repository.findByID("id-email").getType()).isEqualTo(NotifTypeEnum.EMAIL);
+    }
+}

--- a/src/test/java/com/notification/herald/services/CommonPersistanceServiceTest.java
+++ b/src/test/java/com/notification/herald/services/CommonPersistanceServiceTest.java
@@ -1,0 +1,82 @@
+package com.notification.herald.services;
+
+import com.notification.herald.entities.NotificationEntity;
+import com.notification.herald.enums.NotifTypeEnum;
+import com.notification.herald.enums.NotificationStatusEnum;
+import com.notification.herald.repository.NotificationRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CommonPersistanceServiceTest {
+
+    @Mock
+    private NotificationRepository notificationRepository;
+
+    @InjectMocks
+    private CommonPersistanceService commonPersistanceService;
+
+    @Test
+    void saveOrUpdateNotification_whenNoExistingRecord_shouldCreateNewEntity() {
+        when(notificationRepository.findByID("req-1")).thenReturn(null);
+
+        commonPersistanceService.saveOrUpdateNotification("req-1", "ref-abc", 1, NotifTypeEnum.EMAIL, NotificationStatusEnum.REQUESTED);
+
+        ArgumentCaptor<NotificationEntity> captor = ArgumentCaptor.forClass(NotificationEntity.class);
+        verify(notificationRepository).save(captor.capture());
+
+        NotificationEntity saved = captor.getValue();
+        assertThat(saved.getNotificationId()).isEqualTo("req-1");
+        assertThat(saved.getReferenceId()).isEqualTo("ref-abc");
+        assertThat(saved.getType()).isEqualTo(NotifTypeEnum.EMAIL);
+        assertThat(saved.getStatus()).isEqualTo(NotificationStatusEnum.REQUESTED);
+        assertThat(saved.getRetryCount()).isEqualTo(1);
+    }
+
+    @Test
+    void saveOrUpdateNotification_whenExistingRecord_shouldUpdateFields() {
+        NotificationEntity existing = new NotificationEntity("req-1", "old-ref", NotifTypeEnum.EMAIL, NotificationStatusEnum.REQUESTED, 1);
+        when(notificationRepository.findByID("req-1")).thenReturn(existing);
+
+        commonPersistanceService.saveOrUpdateNotification("req-1", "new-ref", 2, NotifTypeEnum.EMAIL, NotificationStatusEnum.FAILED);
+
+        ArgumentCaptor<NotificationEntity> captor = ArgumentCaptor.forClass(NotificationEntity.class);
+        verify(notificationRepository).save(captor.capture());
+
+        NotificationEntity saved = captor.getValue();
+        assertThat(saved.getReferenceId()).isEqualTo("new-ref");
+        assertThat(saved.getRetryCount()).isEqualTo(2);
+        assertThat(saved.getStatus()).isEqualTo(NotificationStatusEnum.FAILED);
+    }
+
+    @Test
+    void saveOrUpdateNotification_whenExistingRecord_shouldNotCreateNewInstance() {
+        NotificationEntity existing = new NotificationEntity("req-1", "old-ref", NotifTypeEnum.SMS, NotificationStatusEnum.REQUESTED, 1);
+        when(notificationRepository.findByID("req-1")).thenReturn(existing);
+
+        commonPersistanceService.saveOrUpdateNotification("req-1", "new-ref", 2, NotifTypeEnum.SMS, NotificationStatusEnum.REQUESTED);
+
+        ArgumentCaptor<NotificationEntity> captor = ArgumentCaptor.forClass(NotificationEntity.class);
+        verify(notificationRepository).save(captor.capture());
+
+        // Should be the same instance, not a new one
+        assertThat(captor.getValue()).isSameAs(existing);
+    }
+
+    @Test
+    void saveOrUpdateNotification_shouldAlwaysCallSave() {
+        when(notificationRepository.findByID(any())).thenReturn(null);
+
+        commonPersistanceService.saveOrUpdateNotification("req-1", "ref-1", 1, NotifTypeEnum.SMS, NotificationStatusEnum.REQUESTED);
+
+        verify(notificationRepository, times(1)).save(any(NotificationEntity.class));
+    }
+}

--- a/src/test/java/com/notification/herald/services/NotificationServiceTest.java
+++ b/src/test/java/com/notification/herald/services/NotificationServiceTest.java
@@ -1,0 +1,138 @@
+package com.notification.herald.services;
+
+import com.notification.herald.dto.NotifRequestDto;
+import com.notification.herald.dto.ResponseDto;
+import com.notification.herald.dto.mail.MailRequestDto;
+import com.notification.herald.dto.sms.SMSRequestDto;
+import com.notification.herald.entities.NotificationEntity;
+import com.notification.herald.enums.NotifTypeEnum;
+import com.notification.herald.enums.NotificationStatusEnum;
+import com.notification.herald.repository.NotificationRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationServiceTest {
+
+    @Mock
+    private KafkaProviderService kafkaProviderService;
+
+    @Mock
+    private NotificationRepository notificationRepository;
+
+    @InjectMocks
+    private NotificationService notificationService;
+
+    @Test
+    void sendNotification_smsRequest_shouldPublishToSmsTopic() {
+        NotifRequestDto request = new NotifRequestDto(NotifTypeEnum.SMS, "+1234567890", null, null, "Hello", null);
+
+        ResponseDto response = notificationService.sendNotification(List.of(request));
+
+        ArgumentCaptor<Object> messageCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(kafkaProviderService).sendMessage(eq("SMS"), messageCaptor.capture());
+        assertThat(messageCaptor.getValue()).isInstanceOf(SMSRequestDto.class);
+
+        SMSRequestDto sms = (SMSRequestDto) messageCaptor.getValue();
+        assertThat(sms.toMobile()).isEqualTo("+1234567890");
+        assertThat(sms.body()).isEqualTo("Hello");
+    }
+
+    @Test
+    void sendNotification_emailRequest_shouldPublishToEmailTopic() {
+        NotifRequestDto request = new NotifRequestDto(NotifTypeEnum.EMAIL, null, "user@example.com", "Alice", "Hello email", "Subject");
+
+        notificationService.sendNotification(List.of(request));
+
+        ArgumentCaptor<Object> messageCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(kafkaProviderService).sendMessage(eq("EMAIL"), messageCaptor.capture());
+        assertThat(messageCaptor.getValue()).isInstanceOf(MailRequestDto.class);
+
+        MailRequestDto mail = (MailRequestDto) messageCaptor.getValue();
+        assertThat(mail.to().email()).isEqualTo("user@example.com");
+        assertThat(mail.subject()).isEqualTo("Subject");
+        assertThat(mail.content()).isEqualTo("Hello email");
+    }
+
+    @Test
+    void sendNotification_shouldReturnListOfRequestIds() {
+        NotifRequestDto r1 = new NotifRequestDto(NotifTypeEnum.SMS, "+111", null, null, "msg", null);
+        NotifRequestDto r2 = new NotifRequestDto(NotifTypeEnum.EMAIL, null, "a@b.com", "Name", "content", "subj");
+
+        ResponseDto response = notificationService.sendNotification(List.of(r1, r2));
+
+        assertThat(response.status()).isEqualTo(HttpStatus.CREATED.value());
+        List<String> ids = (List<String>) response.data();
+        assertThat(ids).hasSize(2);
+        assertThat(ids.get(0)).isNotEqualTo(ids.get(1));
+    }
+
+    @Test
+    void sendNotification_shouldIncludeGeneratedRequestIdInKafkaMessage() {
+        NotifRequestDto request = new NotifRequestDto(NotifTypeEnum.SMS, "+1234567890", null, null, "msg", null);
+
+        ResponseDto response = notificationService.sendNotification(List.of(request));
+        String returnedId = ((List<String>) response.data()).get(0);
+
+        ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
+        verify(kafkaProviderService).sendMessage(any(), captor.capture());
+        SMSRequestDto sms = (SMSRequestDto) captor.getValue();
+
+        assertThat(sms.requestId()).isEqualTo(returnedId);
+    }
+
+    @Test
+    void validateRequest_bothMobileAndEmailNull_shouldThrow400() {
+        NotifRequestDto request = new NotifRequestDto(NotifTypeEnum.SMS, null, null, null, "msg", null);
+
+        assertThatThrownBy(() -> notificationService.sendNotification(List.of(request)))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(ex -> assertThat(((ResponseStatusException) ex).getStatusCode())
+                        .isEqualTo(HttpStatus.BAD_REQUEST));
+    }
+
+    @Test
+    void validateRequest_smsWithNullMobile_shouldThrow400() {
+        NotifRequestDto request = new NotifRequestDto(NotifTypeEnum.SMS, null, "user@example.com", null, "msg", null);
+
+        assertThatThrownBy(() -> notificationService.sendNotification(List.of(request)))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(ex -> assertThat(((ResponseStatusException) ex).getStatusCode())
+                        .isEqualTo(HttpStatus.BAD_REQUEST));
+    }
+
+    @Test
+    void validateRequest_emailWithNullEmail_shouldThrow400() {
+        NotifRequestDto request = new NotifRequestDto(NotifTypeEnum.EMAIL, "+1234567890", null, "Name", "content", "subj");
+
+        assertThatThrownBy(() -> notificationService.sendNotification(List.of(request)))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(ex -> assertThat(((ResponseStatusException) ex).getStatusCode())
+                        .isEqualTo(HttpStatus.BAD_REQUEST));
+    }
+
+    @Test
+    void getNotification_shouldReturnWrappedEntity() {
+        NotificationEntity entity = new NotificationEntity("req-1", "ref-1", NotifTypeEnum.EMAIL, NotificationStatusEnum.REQUESTED, 1);
+        when(notificationRepository.findByID("req-1")).thenReturn(entity);
+
+        ResponseDto response = notificationService.getNotification("req-1");
+
+        assertThat(response.data()).isEqualTo(entity);
+        assertThat(response.status()).isEqualTo(HttpStatus.OK.value());
+    }
+}

--- a/src/test/java/com/notification/herald/services/OtpServiceTest.java
+++ b/src/test/java/com/notification/herald/services/OtpServiceTest.java
@@ -1,0 +1,194 @@
+package com.notification.herald.services;
+
+import com.notification.herald.dto.NotifRequestDto;
+import com.notification.herald.dto.ResponseDto;
+import com.notification.herald.dto.otp.OtpRequestDto;
+import com.notification.herald.dto.otp.OtpValidateDto;
+import com.notification.herald.enums.NotifTypeEnum;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mindrot.jbcrypt.BCrypt;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.Duration;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class OtpServiceTest {
+
+    @Mock
+    private NotificationService notificationService;
+
+    @Mock
+    private RedisTemplate<String, String> redisTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    @InjectMocks
+    private OtpService otpService;
+
+    @BeforeEach
+    void setUp() {
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+    }
+
+    @Test
+    void requestOtp_withEmailOnly_shouldSendEmailNotification() {
+        OtpRequestDto request = new OtpRequestDto(null, "user@example.com", "Your OTP is ${OTP}", "Alice", 300);
+        List<String> requestIds = List.of("req-123");
+        when(notificationService.sendNotification(any())).thenReturn(new ResponseDto(requestIds, HttpStatus.CREATED.value()));
+
+        ResponseDto response = otpService.requestOtp(request);
+
+        ArgumentCaptor<List> captor = ArgumentCaptor.forClass(List.class);
+        verify(notificationService).sendNotification(captor.capture());
+        List<NotifRequestDto> notifications = captor.getValue();
+
+        assertThat(notifications).hasSize(1);
+        assertThat(notifications.get(0).getType()).isEqualTo(NotifTypeEnum.EMAIL);
+        assertThat(response).isNotNull();
+    }
+
+    @Test
+    void requestOtp_withMobileOnly_shouldSendSmsNotification() {
+        OtpRequestDto request = new OtpRequestDto("+1234567890", null, "Your OTP is ${OTP}", null, 300);
+        List<String> requestIds = List.of("req-456");
+        when(notificationService.sendNotification(any())).thenReturn(new ResponseDto(requestIds, HttpStatus.CREATED.value()));
+
+        otpService.requestOtp(request);
+
+        ArgumentCaptor<List> captor = ArgumentCaptor.forClass(List.class);
+        verify(notificationService).sendNotification(captor.capture());
+        List<NotifRequestDto> notifications = captor.getValue();
+
+        assertThat(notifications).hasSize(1);
+        assertThat(notifications.get(0).getType()).isEqualTo(NotifTypeEnum.SMS);
+    }
+
+    @Test
+    void requestOtp_withBothEmailAndMobile_shouldSendTwoNotifications() {
+        OtpRequestDto request = new OtpRequestDto("+1234567890", "user@example.com", "OTP: ${OTP}", "Bob", 300);
+        List<String> requestIds = List.of("req-1", "req-2");
+        when(notificationService.sendNotification(any())).thenReturn(new ResponseDto(requestIds, HttpStatus.CREATED.value()));
+
+        otpService.requestOtp(request);
+
+        ArgumentCaptor<List> captor = ArgumentCaptor.forClass(List.class);
+        verify(notificationService).sendNotification(captor.capture());
+
+        assertThat(captor.getValue()).hasSize(2);
+    }
+
+    @Test
+    void requestOtp_shouldReplaceOtpPlaceholderInContent() {
+        OtpRequestDto request = new OtpRequestDto(null, "user@example.com", "Code: ${OTP}", "Alice", 300);
+        List<String> requestIds = List.of("req-123");
+        when(notificationService.sendNotification(any())).thenReturn(new ResponseDto(requestIds, HttpStatus.CREATED.value()));
+
+        otpService.requestOtp(request);
+
+        ArgumentCaptor<List> captor = ArgumentCaptor.forClass(List.class);
+        verify(notificationService).sendNotification(captor.capture());
+        String content = ((NotifRequestDto) captor.getValue().get(0)).getContent();
+
+        assertThat(content).doesNotContain("${OTP}");
+        assertThat(content).startsWith("Code: ");
+        // The replaced OTP should be 5 digits
+        String otp = content.replace("Code: ", "");
+        assertThat(otp).matches("\\d{5}");
+    }
+
+    @Test
+    void requestOtp_shouldStoreHashedOtpInRedisWithTtl() {
+        OtpRequestDto request = new OtpRequestDto(null, "user@example.com", "OTP: ${OTP}", "Alice", 120);
+        List<String> requestIds = List.of("req-abc");
+        when(notificationService.sendNotification(any())).thenReturn(new ResponseDto(requestIds, HttpStatus.CREATED.value()));
+
+        otpService.requestOtp(request);
+
+        verify(valueOperations).set(eq("otp:" + requestIds), anyString(), eq(Duration.ofSeconds(120)));
+    }
+
+    @Test
+    void validateOtp_withValidOtp_shouldReturnAuthorizedAndDeleteFromRedis() {
+        String requestId = "req-123";
+        String otp = "54321";
+        String hashedOtp = BCrypt.hashpw(otp, BCrypt.gensalt(5));
+
+        when(valueOperations.get("otp:" + requestId)).thenReturn(hashedOtp);
+
+        OtpValidateDto validateDto = new OtpValidateDto();
+        validateDto.setRequestId(requestId);
+        validateDto.setOtp(otp);
+
+        ResponseDto response = otpService.validateOtp(validateDto);
+
+        assertThat(response.data()).isEqualTo("Authorized");
+        assertThat(response.status()).isEqualTo(HttpStatus.OK.value());
+        verify(redisTemplate).delete("otp:" + requestId);
+    }
+
+    @Test
+    void validateOtp_whenOtpNotFoundInRedis_shouldThrow404() {
+        when(valueOperations.get(anyString())).thenReturn(null);
+
+        OtpValidateDto validateDto = new OtpValidateDto();
+        validateDto.setRequestId("req-missing");
+        validateDto.setOtp("12345");
+
+        assertThatThrownBy(() -> otpService.validateOtp(validateDto))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(ex -> assertThat(((ResponseStatusException) ex).getStatusCode())
+                        .isEqualTo(HttpStatus.NOT_FOUND));
+    }
+
+    @Test
+    void validateOtp_withWrongOtp_shouldThrow401() {
+        String requestId = "req-123";
+        String hashedOtp = BCrypt.hashpw("99999", BCrypt.gensalt(5));
+
+        when(valueOperations.get("otp:" + requestId)).thenReturn(hashedOtp);
+
+        OtpValidateDto validateDto = new OtpValidateDto();
+        validateDto.setRequestId(requestId);
+        validateDto.setOtp("11111");
+
+        assertThatThrownBy(() -> otpService.validateOtp(validateDto))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(ex -> assertThat(((ResponseStatusException) ex).getStatusCode())
+                        .isEqualTo(HttpStatus.UNAUTHORIZED));
+    }
+
+    @Test
+    void validateOtp_withWrongOtp_shouldNotDeleteFromRedis() {
+        String requestId = "req-123";
+        String hashedOtp = BCrypt.hashpw("99999", BCrypt.gensalt(5));
+
+        when(valueOperations.get("otp:" + requestId)).thenReturn(hashedOtp);
+
+        OtpValidateDto validateDto = new OtpValidateDto();
+        validateDto.setRequestId(requestId);
+        validateDto.setOtp("11111");
+
+        assertThatThrownBy(() -> otpService.validateOtp(validateDto))
+                .isInstanceOf(ResponseStatusException.class);
+
+        verify(redisTemplate, never()).delete(anyString());
+    }
+}

--- a/src/test/java/com/notification/herald/utils/MailUtilTest.java
+++ b/src/test/java/com/notification/herald/utils/MailUtilTest.java
@@ -1,0 +1,60 @@
+package com.notification.herald.utils;
+
+import com.notification.herald.dto.UserDto;
+import com.notification.herald.dto.mail.MailRequestDto;
+import com.notification.herald.enums.MailProviderEnum;
+import com.notification.herald.providers.mail.MailProvider;
+import org.apache.coyote.BadRequestException;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+class MailUtilTest {
+
+    // Class name "MailjetImpl" → lowercase → "mailjetimpl" → strip "impl" → "mailjet"
+    // Matches MailProviderEnum.MAILJET.getValue() = "mailjet"
+    static class MailjetImpl implements MailProvider {
+        @Override
+        public String sendMail(MailRequestDto request) {
+            return "test-message-id";
+        }
+    }
+
+    private MailRequestDto sampleRequest() {
+        return new MailRequestDto("Subject", "Body", new UserDto("Alice", "user@example.com"), "req-1");
+    }
+
+    @Test
+    void sendMail_withValidProvider_shouldDelegateToProvider() throws Exception {
+        MailjetImpl provider = spy(new MailjetImpl());
+        MailUtil mailUtil = new MailUtil(List.of(provider));
+
+        String result = mailUtil.sendMail(sampleRequest(), MailProviderEnum.MAILJET);
+
+        verify(provider).sendMail(sampleRequest());
+        assertThat(result).isEqualTo("test-message-id");
+    }
+
+    @Test
+    void sendMail_withUnknownProvider_shouldThrowBadRequestException() {
+        MailUtil mailUtil = new MailUtil(List.of());
+
+        assertThatThrownBy(() -> mailUtil.sendMail(sampleRequest(), MailProviderEnum.MAILJET))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining("Invalid email provider");
+    }
+
+    @Test
+    void constructor_shouldRegisterProviderWithStrippedImplKey() throws Exception {
+        MailUtil mailUtil = new MailUtil(List.of(new MailjetImpl()));
+
+        String result = mailUtil.sendMail(sampleRequest(), MailProviderEnum.MAILJET);
+
+        assertThat(result).isEqualTo("test-message-id");
+    }
+}

--- a/src/test/java/com/notification/herald/utils/RequestUtilsTest.java
+++ b/src/test/java/com/notification/herald/utils/RequestUtilsTest.java
@@ -1,0 +1,42 @@
+package com.notification.herald.utils;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RequestUtilsTest {
+
+    @Test
+    void generateRequestId_shouldNotBeNullOrEmpty() {
+        String id = RequestUtils.generateRequestId();
+        assertThat(id).isNotNull().isNotEmpty();
+    }
+
+    @Test
+    void generateRequestId_shouldContainHyphenSeparatingUuidAndTimestamp() {
+        String id = RequestUtils.generateRequestId();
+        // UUID (5 hyphen-separated segments) + "-" + timestamp = at least 6 segments total
+        String[] parts = id.split("-");
+        assertThat(parts.length).isGreaterThanOrEqualTo(6);
+    }
+
+    @Test
+    void generateRequestId_lastSegmentShouldBeNumericTimestamp() {
+        String id = RequestUtils.generateRequestId();
+        String[] parts = id.split("-");
+        String timestamp = parts[parts.length - 1];
+        assertThat(timestamp).matches("\\d+");
+    }
+
+    @Test
+    void generateRequestId_shouldBeUniqueAcrossMultipleCalls() {
+        Set<String> ids = new HashSet<>();
+        for (int i = 0; i < 100; i++) {
+            ids.add(RequestUtils.generateRequestId());
+        }
+        assertThat(ids).hasSize(100);
+    }
+}

--- a/src/test/java/com/notification/herald/utils/SMSUtilTest.java
+++ b/src/test/java/com/notification/herald/utils/SMSUtilTest.java
@@ -1,0 +1,55 @@
+package com.notification.herald.utils;
+
+import com.notification.herald.dto.sms.SMSRequestDto;
+import com.notification.herald.enums.SMSProviderEnum;
+import com.notification.herald.providers.sms.SMSProvider;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+class SMSUtilTest {
+
+    @Test
+    void sendSMS_withValidProvider_shouldDelegateToProvider() {
+        TwilioImpl provider = spy(new TwilioImpl());
+        SMSUtil smsUtil = new SMSUtil(List.of(provider));
+        SMSRequestDto request = new SMSRequestDto("+1234567890", "Hello", "req-1");
+
+        String result = smsUtil.sendSMS(request, SMSProviderEnum.TWILIO);
+
+        verify(provider).sendSMS(request);
+        assertThat(result).isEqualTo("test-sid");
+    }
+
+    @Test
+    void sendSMS_withUnknownProvider_shouldThrowNullPointerException() {
+        // SMSUtil has no null check — calling sendSMS with a provider not in the map NPEs
+        SMSUtil smsUtil = new SMSUtil(List.of());
+        SMSRequestDto request = new SMSRequestDto("+1234567890", "Hello", "req-1");
+
+        assertThatThrownBy(() -> smsUtil.sendSMS(request, SMSProviderEnum.TWILIO))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void constructor_shouldRegisterProviderByStrippedClassName() {
+        SMSUtil smsUtil = new SMSUtil(List.of(new TwilioImpl()));
+        SMSRequestDto request = new SMSRequestDto("+1234567890", "msg", "req-1");
+
+        String result = smsUtil.sendSMS(request, SMSProviderEnum.TWILIO);
+        assertThat(result).isEqualTo("test-sid");
+    }
+
+    // Inner class whose simple name "TwilioImpl" maps to key "twilio"
+    static class TwilioImpl implements SMSProvider {
+        @Override
+        public String sendSMS(SMSRequestDto request) {
+            return "test-sid";
+        }
+    }
+}


### PR DESCRIPTION
- P1: unit tests for services, providers, utils, consumers (38 tests)
- P2: slice tests for controllers and GlobalExceptionHandler (26 tests)
- P3: KafkaConfig, provider failure, and repository tests with Testcontainers Postgres + Flyway (7 tests)
- Add JaCoCo for coverage reporting (88% instruction, 97% branch)
- Add Testcontainers dependencies and Surefire timezone fix (UTC)